### PR TITLE
Fix: spelling mistakes in documentation

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -58,7 +58,7 @@
                   <a class="nav-link" href="https://package-v.com/documentation"> Documentation </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="https://package-v.com/privacity-policy"> Privacity policy </a>
+                  <a class="nav-link" href="https://package-v.com/privacity-policy"> Privacy policy </a>
                 </li>
               </ul>
             </div>
@@ -158,14 +158,14 @@
       </p>
       <p>
         <h5>Alpha and beta versions:</h5> 
-        When a PR is closed and the base branch in this one is different to a develop ("develop", "dev", "development"), qa (qa) and main ("main", "master") branch name, is going to added to the package version a sufix call "alpha".
+        When a PR is closed and the base branch in this one is different to a develop ("develop", "dev", "development"), qa (qa) and main ("main", "master") branch name, is going to added to the package version a suffix call "alpha".
         <p><i>Example:</i> </p>
         <p>PR: feature/login <- fix/title</p>
         <p>current package version: 1.2.0</p>
         <p>Next package version: 1.2.1-alpha</p>
       </p>
       <p>
-        A similar behaviour will happens when a when a PR be closed in the ("develop", "dev", "development"), qa (qa)  branches; the sufix that is oging to be added is going to be "beta":
+        A similar behaviour will happens when a PR be closed in the ("develop", "dev", "development"), qa (qa)  branches; the suffix that is going to be added is going to be "beta":
       </p>
       <p><i>Example:</i></p>
       <p>PR: develop <- feature/login</p>
@@ -193,7 +193,7 @@
       <p>current package version: 1.3.0-beta</p>
       <p>Next package version: 1.3.0-beta</p>
         
-      <p>In addition, similar behaviour is done when a PR is closed in the main (main or master) branch, if this is the base branch, all sufixes in the version will be removed and the merged version will be kept without modification to publish this one to be used in production.</p>
+      <p>In addition, similar behaviour is done when a PR is closed in the main (main or master) branch, if this is the base branch, all suffixes in the version will be removed and the merged version will be kept without modification to publish this one to be used in production.</p>
       <p><i>Example:</i></p>
       <p>PR: main <- qa</p>
       <p>current package version: 1.3.0-beta</p>


### PR DESCRIPTION
Corrected spelling errors in the documentation to enhance clarity and professionalism